### PR TITLE
[ICC-82] 환경 설정 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 
 .env
+.env.*
 FastAPI
 docker-compose.yml
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "vite --mode dev",
+    "build": "vite build --mode prod",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview --mode prod"
   },
   "dependencies": {
     "axios": "^1.9.0",

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
+import CustomToast from "#shared/toast";
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import CustomToast from "#shared/toast";
 import "./Header.css";
 
 const Header = ({ isSidebarOpen, toggleSidebar, setIsSidebarOpen }) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,6 @@ export default defineConfig(({ mode }) => {
         "/api": {
           target: proxyTarget,
           changeOrigin: true,
-          secure: false,
           rewrite: (path) => path.replace(/^\/api/, ""),
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,27 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+// vite.config.ts
+import react from "@vitejs/plugin-react";
+import process from "process";
+import { defineConfig, loadEnv } from "vite";
 
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-})
+export default defineConfig(({ mode }) => {
+  const proxyTarget = loadEnv("prod", process.cwd(), "").VITE_BASE_URL;
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        "/api": {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/^\/api/, ""),
+          configure: (proxy) => {
+            proxy.on("proxyReq", (proxyReq) => {
+              proxyReq.removeHeader("origin");
+            });
+          },
+        },
+      },
+    },
+  };
+});


### PR DESCRIPTION
## 설명
vite proxy: node.js 서버, 요청을 대신해주는 서버입니다
--mode dev에서는 .env.dev를 가져와서  /api로 요청합니다 그것을 vite 프록시가 가로채서 원격 서버에 요청합니다
그러나 크롬브라우저입장에서는 같은 경로 localhost:5173으로 요청하고 응답받은것으로 생각하기때문에 CORS오류가 발생하지 않습니다

빌드시에는 --mode prod로 빌드하므로 .env.prod를 가져와서 원격 서버 주소를 가지고 빌드하게됩니다 

### 코드 설명 - 코드에 코멘트 달아놓겠습니다
## 체크리스트
- [ ] 기존 .env 삭제
- [ ] 노션 - 환경변수 - Client 페이지에 있는 파일 그대로 프로젝트 루트 경로에 생성
- [ ] 코드 리뷰
