### PR TITLE
[ICC-104] 링크 태그로 변경 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,12 @@ import React, { useEffect } from "react";
 import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import "./App.css";
+import Help from "./pages/Help";
 import MakeQuiz from "./pages/MakeQuiz";
 import QuizExplanation from "./pages/QuizExplanation";
+import QuizHistory from "./pages/QuizHistory";
 import QuizResult from "./pages/QuizResult";
 import SolveQuiz from "./pages/SolveQuiz";
-import QuizHistory from "./pages/QuizHistory";
-import Help from "./pages/Help";
 import { initGA, logPageView } from "./utils/analytics";
 
 // Google Analytics 측정 ID (실제 GA4 측정 ID로 교체 필요)

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -33,6 +33,10 @@
   margin-right: 12px;
 }
 
+.logo-link {
+  text-decoration: none;
+}
+
 .logo-icon {
   font-size: 28px;
   color: #6366f1;
@@ -87,6 +91,10 @@
   padding: 16px;
 }
 
+.sidebar nav {
+  width: 100%;
+}
+
 .sidebar nav a {
   display: block;
   padding: 12px 16px;
@@ -112,6 +120,7 @@
   cursor: pointer;
   font-size: 16px;
   transition: all 0.2s ease;
+  box-sizing: border-box;
 }
 
 .nav-link:hover {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,9 @@
 import CustomToast from "#shared/toast";
 import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import "./Header.css";
 
 const Header = ({ isSidebarOpen, toggleSidebar, setIsSidebarOpen }) => {
-  const navigate = useNavigate();
-
   useEffect(() => {
     const handleClickOutside = (e) => {
       const sidebar = document.getElementById("sidebar");
@@ -26,12 +24,10 @@ const Header = ({ isSidebarOpen, toggleSidebar, setIsSidebarOpen }) => {
   // 네비게이션 핸들러들
   const handleMakeQuiz = () => {
     setIsSidebarOpen(false);
-    navigate("/");
   };
 
   const handleQuizManagement = () => {
     setIsSidebarOpen(false);
-    navigate("/history");
   };
 
   const handleStatistics = () => {
@@ -41,11 +37,6 @@ const Header = ({ isSidebarOpen, toggleSidebar, setIsSidebarOpen }) => {
 
   const handleHelp = () => {
     setIsSidebarOpen(false);
-    navigate("/help?source=header");
-  };
-
-  const handleLogoClick = () => {
-    navigate("/");
   };
 
   return (
@@ -59,15 +50,21 @@ const Header = ({ isSidebarOpen, toggleSidebar, setIsSidebarOpen }) => {
           >
             ☰
           </button>
-          <div className="logo-area-inner" onClick={handleLogoClick}>
-            <span className="logo-icon">❓</span>
-            <h1 className="logo-text">Q-Asker</h1>
-          </div>
+          <h1 className="logo-area-inner">
+            <Link to="/" className="logo-link">
+              <span className="logo-icon">❓</span>
+              <span className="logo-text">Q-Asker</span>
+            </Link>
+          </h1>
         </div>
         <div className="nav-link-area">
-          <button className="nav-link" onClick={handleQuizManagement}>
+          <Link
+            to="/history"
+            className="nav-link"
+            onClick={handleQuizManagement}
+          >
             📋 <strong>퀴즈 기록</strong>
-          </button>
+          </Link>
         </div>
       </div>
       <aside
@@ -84,18 +81,26 @@ const Header = ({ isSidebarOpen, toggleSidebar, setIsSidebarOpen }) => {
           </button>
         </div>
         <nav>
-          <button className="nav-link" onClick={handleMakeQuiz}>
+          <Link to="/" className="nav-link" onClick={handleMakeQuiz}>
             ➕ 문제 만들기
-          </button>
-          <button className="nav-link" onClick={handleQuizManagement}>
+          </Link>
+          <Link
+            to="/history"
+            className="nav-link"
+            onClick={handleQuizManagement}
+          >
             📋 퀴즈 기록
-          </button>
+          </Link>
           <button className="nav-link" onClick={handleStatistics}>
             📊 통계
           </button>
-          <button className="nav-link" onClick={handleHelp}>
+          <Link
+            to="/help?source=header"
+            className="nav-link"
+            onClick={handleHelp}
+          >
             ❓ 도움말
-          </button>
+          </Link>
         </nav>
       </aside>
     </header>

--- a/src/pages/MakeQuiz.jsx
+++ b/src/pages/MakeQuiz.jsx
@@ -1,11 +1,11 @@
 // src/pages/MakeQuiz.jsx
 import axiosInstance from "#shared/api";
 import CustomToast from "#shared/toast";
-import { useEffect, useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
+import { useNavigate } from "react-router-dom";
 import Header from "../components/Header";
 import { trackMakeQuizEvents } from "../utils/analytics";
 import "./MakeQuiz.css";
@@ -725,15 +725,15 @@ const MakeQuiz = () => {
       </main>
       {/* Footer */}
       <footer className="footer">
-        © 2025 Q-Asker. All rights reserved. 문의 및 피드백 : inhapj01@gmail.com
-        <br></br>
-        문의 및 지원 구글 폼 :{" "}
+        © 2025 Q-Asker. All rights reserved.
+        <br></br>문의 및 피드백 :
         <a
           href="https://docs.google.com/forms/d/e/1FAIpQLSfibmR4WmBghb74tM0ugldhiutitTsJJx3KN5wYHINpr5GRnw/viewform?usp=dialog"
           target="_blank"
         >
-          문의 링크
+          구글폼 링크
         </a>
+        <span>, inhapj01@gmail.com</span>
       </footer>
     </>
   );


### PR DESCRIPTION
## 📢 설명
서치콘솔에서 인식할 수 있게 클릭 이벤트 리스너로 페이지 이동 말고 링크 태그로 이동하게 했습니다

푸터를 약간 변경하였습니다
기존
![image](https://github.com/user-attachments/assets/482288c5-b5fc-40a7-8fa0-a6ef86fa042c)

이후
![image](https://github.com/user-attachments/assets/112583d3-8078-46e4-acf2-787d23ee7eee)

## ✅ 체크 리스트

- [x] 코드 리뷰