### PR TITLE
v 3.0.2

### DIFF
--- a/src/features/solve-quiz/index.ts
+++ b/src/features/solve-quiz/index.ts
@@ -1,4 +1,5 @@
 export { useSolveQuiz } from './model/useSolveQuiz';
+export type { ProblemSetResponse } from './model/useSolveQuizData';
 export {
   loadResult,
   saveResult,

--- a/src/features/solve-quiz/model/useSolveQuiz.ts
+++ b/src/features/solve-quiz/model/useSolveQuiz.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { NavigateFunction } from 'react-router';
 import { useSolveQuizData } from './useSolveQuizData';
+import type { ProblemSetResponse } from './useSolveQuizData';
 import { useSolveQuizQuestion } from './useSolveQuizQuestion';
 import { isUnanswered } from '../lib/isUnanswered';
 import { useSolveQuizSubmit } from './useSolveQuizSubmit';
@@ -19,6 +20,7 @@ interface UseSolveQuizParams {
   navigate: NavigateFunction;
   problemSetId: string;
   quizzes?: Quiz[];
+  prefetchedData?: ProblemSetResponse | null;
 }
 
 interface UseSolveQuizReturn {
@@ -62,6 +64,7 @@ export const useSolveQuiz = ({
   navigate,
   problemSetId,
   quizzes = [],
+  prefetchedData,
 }: UseSolveQuizParams): UseSolveQuizReturn => {
   const savedProgress = useMemo(() => loadProgress(problemSetId), [problemSetId]);
   const initialOffsetMs = savedProgress?.elapsedMs ?? 0;
@@ -78,6 +81,7 @@ export const useSolveQuiz = ({
     quizzes,
     navigate,
     savedProgress,
+    prefetchedData,
   });
   const { currentTime, elapsedMs } = useSolveQuizTimer(initialOffsetMs);
   const totalQuestions = solveQuizzes.length;

--- a/src/features/solve-quiz/model/useSolveQuizData.ts
+++ b/src/features/solve-quiz/model/useSolveQuizData.ts
@@ -11,7 +11,7 @@ import { useAuthStore } from '#entities/auth';
 import { clearEssayGradeResults, clearEssayAttempts } from './solveQuizProgress';
 
 /** API 응답 데이터 타입 */
-interface ProblemSetResponse {
+export interface ProblemSetResponse {
   generationStatus: 'COMPLETED' | 'GENERATING';
   quizType?: 'BLANK' | 'MULTIPLE' | 'OX' | 'ESSAY';
   quiz: Quiz[];
@@ -29,6 +29,8 @@ interface UseSolveQuizDataParams {
     answers: Record<number, string | null>;
     checks: Record<number, boolean>;
   } | null;
+  /** index.tsx에서 미리 받아온 응답 — 있으면 중복 fetch를 건너뜀 */
+  prefetchedData?: ProblemSetResponse | null;
 }
 
 /** Shadow Copy 확인 응답 */
@@ -89,6 +91,7 @@ export const useSolveQuizData = ({
   quizzes,
   navigate,
   savedProgress,
+  prefetchedData,
 }: UseSolveQuizDataParams): UseSolveQuizDataReturn => {
   const { t } = useTranslation('common');
   const [localQuizzes, setLocalQuizzes] = useState<Quiz[]>([]);
@@ -132,11 +135,13 @@ export const useSolveQuizData = ({
     const fetchQuiz = async (): Promise<void> => {
       try {
         trackQuizEvents.startQuiz(problemSetId);
-        const res = await axiosInstance.get<ProblemSetResponse>(`/problem-set/${problemSetId}`);
-        const status = res.data.generationStatus;
+        const data =
+          prefetchedData ??
+          (await axiosInstance.get<ProblemSetResponse>(`/problem-set/${problemSetId}`)).data;
+        const status = data.generationStatus;
 
         // Shadow Copy 확인: 로그인 사용자면 히스토리 제목 우선, 없으면 problemSet 제목
-        let quizTitle = res.data.title;
+        let quizTitle = data.title;
         let resolvedHistoryId: string | null = null;
         if (accessToken) {
           try {
@@ -167,13 +172,13 @@ export const useSolveQuizData = ({
         }
         setTitle(quizTitle);
 
-        if (res.data.quizType) {
-          setQuizType(res.data.quizType);
+        if (data.quizType) {
+          setQuizType(data.quizType);
         }
-        const typedQuizzes = applyQuizType(res.data.quiz, res.data.quizType);
+        const typedQuizzes = applyQuizType(data.quiz, data.quizType);
 
         if (status === 'COMPLETED') {
-          if (res.data.quizType === 'ESSAY') {
+          if (data.quizType === 'ESSAY') {
             // 서술형: savedProgress가 있으면 새로고침이므로 채점 결과 유지
             const hasEssayProgress =
               savedProgress && Object.values(savedProgress.answers).some((a) => a != null);
@@ -195,13 +200,13 @@ export const useSolveQuizData = ({
         if (status === 'GENERATING') {
           setProblemSetInfo({
             problemSetId,
-            totalCount: res.data.totalCount,
+            totalCount: data.totalCount,
             isStreaming: true,
           });
           if (Array.isArray(typedQuizzes) && typedQuizzes.length > 0) {
             setLocalQuizzes(mergeWithProgress(typedQuizzes, savedProgress));
           }
-          const sessionId = res.data.sessionId;
+          const sessionId = data.sessionId;
           reconnectStream(sessionId);
           setIsLoading(false);
         }

--- a/src/pages/make-quiz/index.tsx
+++ b/src/pages/make-quiz/index.tsx
@@ -191,8 +191,8 @@ const MakeQuiz: React.FC = () => {
   const quizTypes: QuizTypeOption[] = [
     { key: 'ESSAY', label: t('서술형'), icon: FileText },
     { key: 'MULTIPLE', label: t('객관식'), icon: ListChecks },
-    { key: 'BLANK', label: t('빈칸 넣기'), icon: PenLine },
     { key: 'OX', label: t('OX 퀴즈'), icon: CircleDot },
+    { key: 'BLANK', label: t('빈칸 넣기'), icon: PenLine },
   ];
 
   const currentLevel: { title: string; question: string; options: string[] } | undefined =

--- a/src/pages/solve-quiz/EssaySolveQuiz.tsx
+++ b/src/pages/solve-quiz/EssaySolveQuiz.tsx
@@ -3,6 +3,7 @@ import InlineEdit from '@/shared/ui/components/inline-edit';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSolveQuiz } from '#features/solve-quiz';
+import type { ProblemSetResponse } from '#features/solve-quiz';
 import { useQuizGenerationStore } from '#features/quiz-generation';
 import { useAuthStore } from '#entities/auth';
 import { ChevronDown, ChevronUp, LogIn, MessageCircle } from 'lucide-react';
@@ -16,7 +17,9 @@ import { Skeleton } from '@/shared/ui/components/skeleton';
 import { AnimatePresence, motion } from 'framer-motion';
 
 /** 서술형(ESSAY) 전용 퀴즈 풀이 페이지 */
-const EssaySolveQuiz: React.FC = () => {
+const EssaySolveQuiz: React.FC<{ prefetchedData?: ProblemSetResponse | null }> = ({
+  prefetchedData,
+}) => {
   const { t } = useTranslation('solve-quiz');
   const navigate = useNavigate();
   const { problemSetId } = useParams<{ problemSetId: string }>();
@@ -37,6 +40,7 @@ const EssaySolveQuiz: React.FC = () => {
     navigate,
     problemSetId: problemSetId ?? '',
     quizzes,
+    prefetchedData,
   });
   const { quiz } = state;
   const { quiz: quizActions } = actions;

--- a/src/pages/solve-quiz/SolveQuizDesign.tsx
+++ b/src/pages/solve-quiz/SolveQuizDesign.tsx
@@ -3,6 +3,7 @@ import InlineEdit from '@/shared/ui/components/inline-edit';
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSolveQuiz } from '#features/solve-quiz';
+import type { ProblemSetResponse } from '#features/solve-quiz';
 import { isUnanswered } from '../../features/solve-quiz/lib/isUnanswered';
 import { useQuizGenerationStore } from '#features/quiz-generation';
 import { useAuthStore } from '#entities/auth';
@@ -53,7 +54,9 @@ const BlankSlot: React.FC<{
 );
 
 /** 퀴즈 풀이 디자인: 타이핑 우선 + 선택지 폴백 */
-const SolveQuizDesign: React.FC = () => {
+const SolveQuizDesign: React.FC<{ prefetchedData?: ProblemSetResponse | null }> = ({
+  prefetchedData,
+}) => {
   const { t } = useTranslation('solve-quiz');
   const navigate = useNavigate();
   const { problemSetId } = useParams<{ problemSetId: string }>();
@@ -74,6 +77,7 @@ const SolveQuizDesign: React.FC = () => {
     navigate,
     problemSetId: problemSetId ?? '',
     quizzes,
+    prefetchedData,
   });
   const { quiz } = state;
   const { quiz: quizActions } = actions;

--- a/src/pages/solve-quiz/index.tsx
+++ b/src/pages/solve-quiz/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useQuizGenerationStore } from '#features/quiz-generation';
 import type { QuizType } from '#features/quiz-generation';
+import type { ProblemSetResponse } from '#features/solve-quiz';
 import axiosInstance from '#shared/api';
 
 const SolveQuizDesign = lazy(() => import('./SolveQuizDesign'));
@@ -10,33 +10,28 @@ const EssaySolveQuiz = lazy(() => import('./EssaySolveQuiz'));
 /** 퀴즈 타입을 감지하여 ESSAY / 선택형 컴포넌트를 분기 렌더 */
 const SolveQuizPage: React.FC = () => {
   const { problemSetId } = useParams<{ problemSetId: string }>();
-  const storeQuizzes = useQuizGenerationStore((s) => s.quizzes);
-  const storeProblemSetId = useQuizGenerationStore((s) => s.problemSetId);
-
-  const [quizType, setQuizType] = useState<QuizType | null>(() => {
-    // 스토어에 동일 problemSet의 퀴즈가 있으면 타입 즉시 확인
-    if (String(storeProblemSetId) === String(problemSetId) && storeQuizzes[0]?.type) {
-      return storeQuizzes[0].type;
-    }
-    return null;
-  });
+  const [quizType, setQuizType] = useState<QuizType | null>(null);
+  const [prefetchedData, setPrefetchedData] = useState<ProblemSetResponse | null>(null);
 
   useEffect(() => {
-    if (quizType) return;
-    // 스토어에 없으면 API에서 타입 확인
     axiosInstance
-      .get<{ quizType?: QuizType; quiz?: { type?: QuizType }[] }>(`/problem-set/${problemSetId}`)
+      .get<ProblemSetResponse>(`/problem-set/${problemSetId}`)
       .then((res) => {
+        setPrefetchedData(res.data);
         setQuizType(res.data.quizType ?? res.data.quiz?.[0]?.type ?? 'MULTIPLE');
       })
       .catch(() => setQuizType('MULTIPLE'));
-  }, [problemSetId, quizType]);
+  }, [problemSetId]);
 
   if (!quizType) return null;
 
   return (
     <Suspense fallback={null}>
-      {quizType === 'ESSAY' ? <EssaySolveQuiz /> : <SolveQuizDesign />}
+      {quizType === 'ESSAY' ? (
+        <EssaySolveQuiz prefetchedData={prefetchedData} />
+      ) : (
+        <SolveQuizDesign prefetchedData={prefetchedData} />
+      )}
     </Suspense>
   );
 };

--- a/src/widgets/recent-changes/model/useRecentChanges.ts
+++ b/src/widgets/recent-changes/model/useRecentChanges.ts
@@ -5,7 +5,7 @@ import type { BoardPost } from '../../../shared/types/board';
 import { MOCK_UPDATE_LOG_POSTS } from '../../../pages/board/mockBoardData';
 
 /** 미리보기용 최대 표시 건수 */
-const PREVIEW_SIZE = 3;
+const PREVIEW_SIZE = 5;
 
 interface UseRecentChangesReturn {
   state: {


### PR DESCRIPTION
* [ICC-333] ⚡ perf: solve-quiz 진입 시 /problem-set 중복 호출 제거

상위 페이지에서 한 번 fetch한 응답을 prefetchedData로 하위 훅에 전달해
useSolveQuizData에서의 중복 요청을 건너뛴다.

* [ICC-333] 💄 style: 퀴즈 타입 선택 순서 변경 — OX 퀴즈를 빈칸 넣기 앞으로

* [ICC-333] 🚸 ux: 최근 변경사항 미리보기 표시 개수 3 → 5

<!-- prettier-ignore-start -->
## 📢 설명

### 변경 1: [제목]

[변경에 대한 설명]

#### 의사 선택과정 (trade-off)

> trade-off가 있는 경우에만 작성

**얻은 것**
-

**잃은 것**
-

### 코드 설명: 인라인 코멘트 확인

## ✅ 체크 리스트

### 재현 확인
<!-- 리뷰어가 직접 따라하며 변경사항을 확인할 수 있는 단계 -->
- [ ] (PR 작성 시 채워주세요)

### 기본
- [ ] 의사 선택 과정이 적절한지 확인
- [ ] 코드 리뷰

---
<!-- prettier-ignore-end -->


[ICC-333]: https://inha-cc-01.atlassian.net/browse/ICC-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ICC-333]: https://inha-cc-01.atlassian.net/browse/ICC-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ICC-333]: https://inha-cc-01.atlassian.net/browse/ICC-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ