### PR TITLE
[ICC-396] Playwright 스모크 게이트 하네스 구성 (issue #358)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ shrimp-rules.md
 screenshots/
 .specify
 specs
+
+# Playwright
+test-results/
+playwright-report/
+/playwright/.cache/

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 공개 라우트 스모크 (백엔드 불필요).
+ * - 로그인·API 없이도 통과해야 하는 최소 게이트.
+ * - 검증: 앱이 #root 에 마운트되고, 페이지 런타임 에러(pageerror)가 없어야 한다.
+ * - 폴더 기능 등 로그인/백엔드가 필요한 e2e 는 구현 단계에서 별도 spec 으로 추가한다.
+ */
+const publicRoutes = ['/', '/privacy-policy', '/terms-of-service'];
+
+for (const route of publicRoutes) {
+  test(`공개 라우트 렌더: ${route}`, async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    const res = await page.goto(route, { waitUntil: 'domcontentloaded' });
+    expect(res, `응답 없음: ${route}`).not.toBeNull();
+    expect(res!.status(), `HTTP 상태 ${res!.status()} @ ${route}`).toBeLessThan(400);
+
+    // React 앱이 실제로 마운트되어 내용이 채워졌는지 (auto-retry 어서션)
+    await expect(page.locator('#root')).not.toBeEmpty();
+
+    expect(pageErrors, `런타임 에러 @ ${route}:\n${pageErrors.join('\n')}`).toHaveLength(0);
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.2.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1923,6 +1924,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prerenderer/prerenderer": {
@@ -12648,6 +12665,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.2.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright 스모크 설정 (하네스).
+ * - 목적: 프론트 작업 마무리 시, 백엔드 없이도 앱이 기동되고 공개 라우트가
+ *   치명적 오류 없이 렌더되는지 강제 검증한다. (.claude/hooks/playwright-gate.sh 에서 호출)
+ * - webServer: vite dev 를 자동 기동하고, 이미 떠 있으면 재사용한다.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['line']],
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
에이전트 팀 기반 프론트/백엔드 동시 작업을 위한 프론트 검증 하네스.
- @playwright/test + playwright.config.ts (vite dev 자동 기동)
- e2e/smoke.spec.ts: 공개 라우트 렌더 스모크 (백엔드 불필요)
- test-results/ 등 Playwright 산출물 gitignore


Claude-Session: https://claude.ai/code/session_01Mgfk1hHDYVr7iT1qt5zm6N

<!-- prettier-ignore-start -->
## 📢 설명

### 변경 1: [제목]

[변경에 대한 설명]

#### 의사 선택과정 (trade-off)

> trade-off가 있는 경우에만 작성

**얻은 것**
-

**잃은 것**
-

### 코드 설명: 인라인 코멘트 확인

## ✅ 체크 리스트

### 재현 확인
<!-- 리뷰어가 직접 따라하며 변경사항을 확인할 수 있는 단계 -->
- [ ] (PR 작성 시 채워주세요)

### 기본
- [ ] 의사 선택 과정이 적절한지 확인
- [ ] 코드 리뷰

---
<!-- prettier-ignore-end -->
